### PR TITLE
:magic_wand: Ajouter un exemple pour l'opérateur  `|` et section "OneLiners"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,24 @@ mobitag send --to xxxxxx --message "Hello World : a mobit@g from Go(lang) XD"
 mobitag send --to xxxxxx --message "Hello World : a mobit@g from Go(lang) XD" --from yyyyyy
 ```
 
-## 🦥 Autocomplétion
+# 🤓 Cool oneliners
+
+Depuis le terminal, les oneliners sont super cools : en une commande concise exécutée en une seule ligne dans un terminal ou un script
+cela permet d’accomplir des tâches rapidement et efficacement, sans avoir à écrire un programme complet.
+
+## Gestion du `pipe` avec la commande `sendPipe`
+
+> "Hey I don't have to do anything here except glue together things that somebody else did 
+for me already" - Brian Kernighan ([see short](https://youtube.com/clip/UgkxtOCaReaRRQCOu5Oo5rrOgCwb56JoX7Gw?si=cJ1TTdKZbArizMmt))
+
+
+```sh
+# Exemple avec la commande `whoami`
+echo "Hello $(whoami) : alors on se le fait ce café ?" |\
+    mobitag sendPipe --to $DIDI_MOBILE
+```
+
+# 🦥 Autocomplétion
 
 Pour une UX optimale dans le terminal, il est possible d'activer l'autocomplétion :
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,39 @@ echo "Hello c'est $(whoami) : alors on se le fait ce café ?" |\
     mobitag sendPipe --to $DIDI_MOBILE
 ```
 
+## ㊙️ Envoyer un fichier ou des secrets avec `privatebin`
+
+[`privatebin`](https://privatebin.info/) est...
+
+> a minimalist, open source online pastebin where the server has zero knowledge of pasted data.
+
+On va ici l'utiliser pour envoyer des fichiers directement par `sms` depuis le terminal.
+
+1. Disposer d'une instance à soi ou en choisir une sur [privatebin.info/directory/](https://privatebin.info/directory/)
+2. Créer le [fichier de conf](https://github.com/gearnode/privatebin/blob/master/doc/privatebin.conf.5.md#examples) `~/.config/privatebin/config.json`
+3. Télécharger et installer [`gearnode/privatebin`](https://github.com/gearnode/privatebin)
+4. Profiter
+
+### 🐮 Un petit coup de `cowsay`
+
+Avec [`cowsay`](https://cowsay.diamonds/):
+
+```sh
+cowsay -f tux "Mobitag c'est VACHEMENT cool...surtout depuis le terminal et pipé avec privatebin"\
+    | privatebin create\
+    | mobitag sendPipe --to $MOBILIS_DEST
+```
+
+### 🔐 Communiquer un fichier de secrets
+
+```sh
+cat secrets.txt\
+    | privatebin create\
+    | mobitag sendPipe --to $MOBILIS_DEST
+```
+
+
+
 # 🦥 Autocomplétion
 
 Pour une UX optimale dans le terminal, il est possible d'activer l'autocomplétion :

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for me already" - Brian Kernighan ([see short](https://youtube.com/clip/UgkxtOCa
 
 ```sh
 # Exemple avec la commande `whoami`
-echo "Hello $(whoami) : alors on se le fait ce café ?" |\
+echo "Hello c'est $(whoami) : alors on se le fait ce café ?" |\
     mobitag sendPipe --to $DIDI_MOBILE
 ```
 

--- a/cmd/sendPipe.go
+++ b/cmd/sendPipe.go
@@ -17,7 +17,7 @@ var sendPipeCmd = &cobra.Command{
 	Long:    `Envoi d'un Mobitag à un numéro de téléphone depuis un pipe.`,
 	Example: `<sortie d'une commande> | mobitag sendPipe --to <destinataire> --from <expéditeur>
 pwd | mobitag sp --to 123456 --from 654321
-echo "Hello $(whoami) : alors on se le fait ce café ?" | mobitag sp -t 123456 -f 654321`,
+echo "Hello c'est $(whoami) : alors on se le fait ce café ?" | mobitag sp -t 123456 -f 654321`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if os.Getenv("OPTNC_MOBITAGNC_API_KEY") == "" {
 			log.Fatalf("❗ La clé API 'OPTNC_MOBITAGNC_API_KEY' n'est pas définie dans les variables d'environnement.")

--- a/cmd/sendPipe.go
+++ b/cmd/sendPipe.go
@@ -17,7 +17,7 @@ var sendPipeCmd = &cobra.Command{
 	Long:    `Envoi d'un Mobitag à un numéro de téléphone depuis un pipe.`,
 	Example: `<sortie d'une commande> | mobitag sendPipe --to <destinataire> --from <expéditeur>
 pwd | mobitag sp --to 123456 --from 654321
-whoami | mobitag sp -t 123456 -f 654321`,
+echo "Hello $(whoami) : alors on se le fait ce café ?" | mobitag sp -t 123456 -f 654321`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if os.Getenv("OPTNC_MOBITAGNC_API_KEY") == "" {
 			log.Fatalf("❗ La clé API 'OPTNC_MOBITAGNC_API_KEY' n'est pas définie dans les variables d'environnement.")


### PR DESCRIPTION
Met en valeur cette super feature qu'est
- https://github.com/opt-nc/mobitag-cli/issues/6

Fixes #58