### PR TITLE
📖 Adress book : Ajout d'un Taskfile pour gérer des alias :test_tube: 

### DIFF
--- a/contribs/Taskfile.yml
+++ b/contribs/Taskfile.yml
@@ -1,0 +1,75 @@
+version: '3'
+
+vars:
+  CONFIG_DIR: "~/.config/mobitag"
+  ALIAS_FILE: "{{.CONFIG_DIR}}/alias.json"
+  EXPORT_SCRIPT: "{{.CONFIG_DIR}}/export_aliases.sh"
+
+tasks:
+  setup:
+    desc: "Ensure config directory and alias.json file exist"
+    cmds:
+      - "mkdir -p {{.CONFIG_DIR}}"
+      - "[ -f {{.ALIAS_FILE}} ] || echo '[]' > {{.ALIAS_FILE}}"
+
+  alias:add:
+    desc: "Add or update an alias"
+    cmds:
+      - "mkdir -p {{.CONFIG_DIR}}"
+      - "[ -f {{.ALIAS_FILE}} ] || echo '[]' > {{.ALIAS_FILE}}"
+      - |
+        if [ -z "{{.NAME}}" ] || [ -z "{{.NUMBER}}" ]; then 
+          echo "Usage: task alias:add NAME=John NUMBER=+1234567890"; 
+          exit 1; 
+        fi
+      - |
+        jq '. |= map(if .name == "{{.NAME}}" then .number = "{{.NUMBER}}" | .type = "{{.TYPE}}" | .notes = "{{.NOTES}}" else . end)' {{.ALIAS_FILE}} > {{.ALIAS_FILE}}.tmp && mv {{.ALIAS_FILE}}.tmp {{.ALIAS_FILE}} || echo "Alias updated"
+        # If alias doesn't exist, add it
+      - |
+        jq 'if (map(select(.name == "{{.NAME}}")) | length) == 0 then . + [{"name": "{{.NAME}}", "number": "{{.NUMBER}}", "type": "{{.TYPE}}", "notes": "{{.NOTES}}"}] else . end' {{.ALIAS_FILE}} > {{.ALIAS_FILE}}.tmp && mv {{.ALIAS_FILE}}.tmp {{.ALIAS_FILE}} || echo "Alias added"
+
+  alias:list:
+    desc: "List all stored aliases"
+    cmds:
+      - "[ -f {{.ALIAS_FILE}} ] || echo '[]' > {{.ALIAS_FILE}}"
+      - "jq '.' {{.ALIAS_FILE}}"
+
+  alias:resolve:
+    desc: "Get the phone number for an alias"
+    cmds:
+      - "[ -f {{.ALIAS_FILE}} ] || echo '[]' > {{.ALIAS_FILE}}"
+      - |
+        if [ -z "{{.NAME}}" ]; then 
+          echo "Usage: task alias:resolve NAME=John"; 
+          exit 1; 
+        fi
+      - "jq -r '.[] | select(.name == \"{{.NAME}}\") | .number // \"Alias not found\"' {{.ALIAS_FILE}}"
+
+  alias:remove:
+    desc: "Remove an alias"
+    cmds:
+      - "mkdir -p {{.CONFIG_DIR}}"
+      - "[ -f {{.ALIAS_FILE}} ] || echo '[]' > {{.ALIAS_FILE}}"
+      - |
+        if [ -z "{{.NAME}}" ]; then 
+          echo "Usage: task alias:remove NAME=John"; 
+          exit 1; 
+        fi
+      - "jq 'del(.[] | select(.name == \"{{.NAME}}\"))' {{.ALIAS_FILE}} > {{.ALIAS_FILE}}.tmp && mv {{.ALIAS_FILE}}.tmp {{.ALIAS_FILE}} || echo 'Alias not found.'"
+
+  alias:export:
+    desc: "Generate a script to export aliases as environment variables"
+    cmds:
+      - "mkdir -p {{.CONFIG_DIR}}"
+      - "[ -f {{.ALIAS_FILE}} ] || echo '[]' > {{.ALIAS_FILE}}"
+      - |
+        echo "#!/bin/bash" > {{.EXPORT_SCRIPT}}
+        echo "# Run 'source {{.EXPORT_SCRIPT}}' to load aliases" >> {{.EXPORT_SCRIPT}}
+        jq -r '.[] | "export MOBILIS_" + (.name | ascii_upcase) + "=\"" + .number + "\"" ' {{.ALIAS_FILE}} >> {{.EXPORT_SCRIPT}}
+      - "chmod +x {{.EXPORT_SCRIPT}}"
+      - "echo 'Run \"source {{.EXPORT_SCRIPT}}\" to load aliases into the current session.'"
+
+  default:
+    desc: "Run a default task if no task is specified"
+    cmds:
+      - echo "No task specified. Run one of the defined tasks like 'task alias:add', 'task alias:list', etc."


### PR DESCRIPTION
# :grey_question: A propos

L'idée est d'**implémenter une premier proto fonctionnel afin de se faire une idée** de ce à quoi pourrait ressembler : 

- https://github.com/opt-nc/mobitag-cli/issues/9

... mais avec un GoTask histoire de voire un peu l'UX qui en découle avant de développer quoi que ce soit.

Cela permet de se projeter sur par exemple:

- la structure du fichier stockant les données
- le lieu de stickage de ce fichier
- des exemples d'import/export de ce fichier `json`, notamment avec des systèmes tierces (annuaire [GMail](https://github.com/opt-nc/mobitag-cli/issues/9#issuecomment-2675628553), vCards, appels d'APIs,...)

# :bulb: Démo

Ajouter un alias : 

```sh
task alias:add NAME=S#### NUMBER=8*****
```

Lister:

```sh
task alias:list
```

Retrouver un alias

```sh
task alias:resolve NAME=Soledad
```

Générer le shel pour exporter en variables d'env

```sh
task alias:export
```

... il ne reste plus qu'à utiliser les alias `MOBLIS_X` depuis le terminal pour envoyer des sms facilement.

Exemple d'intégrtation  avec `duckdb`

![image](https://github.com/user-attachments/assets/34c66d0f-0434-46f8-a78a-9145858763e1)
